### PR TITLE
use json.MarshalIndent instead of json.Marshal to apply indentation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,7 +176,7 @@ func RenderJsonOutput(results pq.PriorityQueue, limit int, renderTarget io.Write
 		repos = append(repos, item.Value.(Repo))
 	}
 
-	jsonOutput, err := json.Marshal(repos)
+	jsonOutput, err := json.MarshalIndent(repos, "", "    ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses [issue nb #7](https://github.com/Link-/gh-stars/issues/7)