### PR TITLE
Enhance Search Functionality

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -243,13 +243,6 @@ func TestSearch(t *testing.T) {
 		pqDepth int
 	}{
 		{
-			name:    "SearchWithEmptyTerm",
-			data:    testData,
-			wantErr: false,
-			find:    "",
-			pqDepth: 0,
-		},
-		{
 			name:    "SearchWithSingleTerm",
 			data:    testData,
 			wantErr: false,
@@ -261,13 +254,13 @@ func TestSearch(t *testing.T) {
 			data:    testData,
 			wantErr: false,
 			find:    "y",
-			pqDepth: 7,
+			pqDepth: 4,
 		},
 		{
 			name:    "SearchWithMultipleWords",
 			data:    testData,
 			wantErr: false,
-			find:    "amethyst engine",
+			find:    "fuzzy search",
 			pqDepth: 1,
 		},
 		{
@@ -285,10 +278,31 @@ func TestSearch(t *testing.T) {
 			pqDepth: 1,
 		},
 		{
-			name:    "SearchProximitySuccess",
+			name:    "ExactMatchRepoName",
 			data:    testData,
 			wantErr: false,
-			find:    "gateleeper",
+			find:    "nanoGPT",
+			pqDepth: 1,
+		},
+		{
+			name:    "ExactMatchTopic",
+			data:    testData,
+			wantErr: false,
+			find:    "gh-extension",
+			pqDepth: 1,
+		},
+		{
+			name:    "NoMatch",
+			data:    testData,
+			wantErr: false,
+			find:    "nonexistent",
+			pqDepth: 0,
+		},
+		{
+			name:    "CaseInsensitiveSearch",
+			data:    testData,
+			wantErr: false,
+			find:    "mAcOS",
 			pqDepth: 1,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/cli/go-gh v1.2.1
-	github.com/lithammer/fuzzysearch v1.1.5
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.7.5
 )
@@ -28,7 +27,6 @@ require (
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/lithammer/fuzzysearch v1.1.5 h1:Ag7aKU08wp0R9QCfF4GoGST9HbmAIeLP7xwMrOBEp1c=
-github.com/lithammer/fuzzysearch v1.1.5/go.mod h1:1R1LRNk7yKid1BaQkmuLQaHruxcC4HmAH30Dh61Ih1Q=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -66,8 +64,6 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
-golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=


### PR DESCRIPTION
This PR addresses [Issue #10](https://github.com/Link-/gh-stars/issues/10).

#### Changes:
- Update `Search` function to use `strings.Contains` function to find matching repos instead of comparing strings using `github.com/lithammer/fuzzysearch/fuzzy.LevenshteinDistance`.
- Update `TestSearch` test function: 
  1 - remove irrelevant test cases, example: find: "" (empty string), the `--find` flag is required, so this case won't occur.
  2 - update the `pqDepth` field in test cases, because the way `Search` function has changed, the results will be affected as well.
  3 - add new test cases to cover more scenarios.
 - Update `go.mod` and `go.sum` files, since we are no longer relying on `github.com/lithammer/fuzzysearch` for searching, this module is no longer needed, so there is no need to include it in `go.mod`.